### PR TITLE
fix: Selected/hovered note background in latest SN version

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -41,4 +41,6 @@
   
     --sn-stylekit-scrollbar-thumb-color: #7F7F7F;
     --sn-stylekit-scrollbar-track-border-color: #8A8A8A;
+    
+    --sn-stylekit-grey-5: #080808;
   }


### PR DESCRIPTION
This PR fixes the background color for selected/hovered notes in v3.9.14