### PR TITLE
Fix for white on white and darken auth screen (2nd attempt)

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -43,4 +43,6 @@
     --sn-stylekit-scrollbar-track-border-color: #8A8A8A;
     
     --sn-stylekit-grey-5: #080808;
+    --navigation-item-selected-background-color: #080808;
+    --sn-stylekit-passive-color-5: #000000;
   }


### PR DESCRIPTION
This is another attempt at the issue and fix raised originally here #11. Hopefully with this, the only issue I found on standard notes best theme is fixed!